### PR TITLE
Add error logging to `TCPSocket::setup()`

### DIFF
--- a/ur_robot_driver/include/ur_robot_driver/comm/stream.h
+++ b/ur_robot_driver/include/ur_robot_driver/comm/stream.h
@@ -110,7 +110,7 @@ protected:
   {
     if (::connect(socket_fd, address, address_len) == -1)
     {
-      LOG_ERROR("connect() error in URStream: %s", strerror(errno));
+      LOG_ERROR("connect() error in URStream %s: %s", toString().c_str(), strerror(errno));
       return false;
     }
     return true;

--- a/ur_robot_driver/include/ur_robot_driver/comm/stream.h
+++ b/ur_robot_driver/include/ur_robot_driver/comm/stream.h
@@ -110,7 +110,7 @@ protected:
   {
     if (::connect(socket_fd, address, address_len) == -1)
     {
-      LOG_ERROR("connect() error: %s", strerror(errno));
+      LOG_ERROR("connect() error in URStream: %s", strerror(errno));
       return false;
     }
     return true;

--- a/ur_robot_driver/include/ur_robot_driver/comm/stream.h
+++ b/ur_robot_driver/include/ur_robot_driver/comm/stream.h
@@ -19,6 +19,7 @@
  */
 
 #pragma once
+#include <errno.h>
 #include <netdb.h>
 #include <sys/socket.h>
 #include <sys/types.h>
@@ -107,7 +108,12 @@ public:
 protected:
   virtual bool open(int socket_fd, struct sockaddr* address, size_t address_len)
   {
-    return ::connect(socket_fd, address, address_len) == 0;
+    if (::connect(socket_fd, address, address_len) == -1)
+    {
+      LOG_ERROR("connect() error: %s", strerror(errno));
+      return false;
+    }
+    return true;
   }
 
 private:

--- a/ur_robot_driver/include/ur_robot_driver/comm/tcp_socket.h
+++ b/ur_robot_driver/include/ur_robot_driver/comm/tcp_socket.h
@@ -42,6 +42,8 @@ enum class SocketState
   Closed         ///< Connection to socket got closed
 };
 
+static const std::string SocketStateStrings[] = { "Invalid", "Connected", "Disconnected", "Closed" };
+
 /*!
  * \brief Class for TCP socket abstraction
  */
@@ -50,6 +52,13 @@ class TCPSocket
 private:
   std::atomic<int> socket_fd_;
   std::atomic<SocketState> state_;
+  std::string host_;
+  int port_;
+
+  std::string getSocketStateString(const SocketState s) const
+  {
+    return SocketStateStrings[static_cast<int>(s)];
+  }
 
 protected:
   virtual bool open(int socket_fd, struct sockaddr* address, size_t address_len)
@@ -61,6 +70,12 @@ protected:
   bool setup(std::string& host, int port);
 
   std::unique_ptr<timeval> recv_timeout_;
+
+  std::string toString() const
+  {
+    return "TCPSocket(host=" + host_ + ", port=" + std::to_string(port_) +
+           ", state=" + getSocketStateString(state_.load()) + ", fd=" + std::to_string(socket_fd_.load()) + ")";
+  }
 
 public:
   /*!

--- a/ur_robot_driver/include/ur_robot_driver/ur/dashboard_client.h
+++ b/ur_robot_driver/include/ur_robot_driver/ur/dashboard_client.h
@@ -85,7 +85,7 @@ protected:
   {
     if (::connect(socket_fd, address, address_len) == -1)
     {
-      LOG_ERROR("connect() error: %s", strerror(errno));
+      LOG_ERROR("connect() error in DashboardClient: %s", strerror(errno));
       return false;
     }
     return true;

--- a/ur_robot_driver/include/ur_robot_driver/ur/dashboard_client.h
+++ b/ur_robot_driver/include/ur_robot_driver/ur/dashboard_client.h
@@ -85,7 +85,7 @@ protected:
   {
     if (::connect(socket_fd, address, address_len) == -1)
     {
-      LOG_ERROR("connect() error in DashboardClient: %s", strerror(errno));
+      LOG_ERROR("connect() error in DashboardClient %s: %s", toString().c_str(), strerror(errno));
       return false;
     }
     return true;

--- a/ur_robot_driver/include/ur_robot_driver/ur/dashboard_client.h
+++ b/ur_robot_driver/include/ur_robot_driver/ur/dashboard_client.h
@@ -27,7 +27,10 @@
 #ifndef UR_ROBOT_DRIVER_DASHBOARD_CLIENT_DASHBOARD_CLIENT_H_INCLUDED
 #define UR_ROBOT_DRIVER_DASHBOARD_CLIENT_DASHBOARD_CLIENT_H_INCLUDED
 
+#include <errno.h>
+
 #include <ur_robot_driver/comm/tcp_socket.h>
+#include <ur_robot_driver/log.h>
 
 namespace ur_driver
 {
@@ -80,7 +83,12 @@ public:
 protected:
   virtual bool open(int socket_fd, struct sockaddr* address, size_t address_len)
   {
-    return ::connect(socket_fd, address, address_len) == 0;
+    if (::connect(socket_fd, address, address_len) == -1)
+    {
+      LOG_ERROR("connect() error: %s", strerror(errno));
+      return false;
+    }
+    return true;
   }
 
 private:

--- a/ur_robot_driver/src/comm/server.cpp
+++ b/ur_robot_driver/src/comm/server.cpp
@@ -64,7 +64,7 @@ bool URServer::open(int socket_fd, struct sockaddr* address, size_t address_len)
   setsockopt(socket_fd, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(int));
   if (::bind(socket_fd, address, address_len) == -1)
   {
-    LOG_ERROR("bind() error in URServer: %s", strerror(errno));
+    LOG_ERROR("bind() error in URServer %s: %s", toString().c_str(), strerror(errno));
     return false;
   }
   return true;

--- a/ur_robot_driver/src/comm/server.cpp
+++ b/ur_robot_driver/src/comm/server.cpp
@@ -22,6 +22,7 @@
 
 #include "ur_robot_driver/comm/server.h"
 #include <arpa/inet.h>
+#include <errno.h>
 #include <netinet/tcp.h>
 #include <unistd.h>
 #include <cstring>
@@ -61,7 +62,12 @@ bool URServer::open(int socket_fd, struct sockaddr* address, size_t address_len)
 {
   int flag = 1;
   setsockopt(socket_fd, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(int));
-  return ::bind(socket_fd, address, address_len) == 0;
+  if (::bind(socket_fd, address, address_len) == -1)
+  {
+    LOG_ERROR("bind() error: %s", strerror(errno));
+    return false;
+  }
+  return true;
 }
 
 bool URServer::bind()

--- a/ur_robot_driver/src/comm/server.cpp
+++ b/ur_robot_driver/src/comm/server.cpp
@@ -64,7 +64,7 @@ bool URServer::open(int socket_fd, struct sockaddr* address, size_t address_len)
   setsockopt(socket_fd, SOL_SOCKET, SO_REUSEADDR, &flag, sizeof(int));
   if (::bind(socket_fd, address, address_len) == -1)
   {
-    LOG_ERROR("bind() error: %s", strerror(errno));
+    LOG_ERROR("bind() error in URServer: %s", strerror(errno));
     return false;
   }
   return true;

--- a/ur_robot_driver/src/comm/tcp_socket.cpp
+++ b/ur_robot_driver/src/comm/tcp_socket.cpp
@@ -73,7 +73,7 @@ bool TCPSocket::setup(std::string& host, int port)
   hints.ai_socktype = SOCK_STREAM;
   hints.ai_flags = AI_PASSIVE;
 
-  int addr_info_result = getaddrinfo(host_name, service.c_str(), &hints, &result);
+  const int addr_info_result = getaddrinfo(host_name, service.c_str(), &hints, &result);
   if (addr_info_result != 0)
   {
     LOG_ERROR("Failed to get address for %s:%d; %s", host.c_str(), port, gai_strerror(addr_info_result));
@@ -88,7 +88,7 @@ bool TCPSocket::setup(std::string& host, int port)
 
     if (socket_fd_ == -1)
     {
-      LOG_ERROR("socket() error: %s", strerror(errno));
+      LOG_WARN("socket() error: %s", strerror(errno));
       continue;
     }
 

--- a/ur_robot_driver/src/comm/tcp_socket.cpp
+++ b/ur_robot_driver/src/comm/tcp_socket.cpp
@@ -76,7 +76,7 @@ bool TCPSocket::setup(std::string& host, int port)
   int addr_info_result = getaddrinfo(host_name, service.c_str(), &hints, &result);
   if (addr_info_result != 0)
   {
-    LOG_ERROR("Failed to get address for %s:%d; %s", host.c_str(), port, gai_error(addr_info_result));
+    LOG_ERROR("Failed to get address for %s:%d; %s", host.c_str(), port, gai_strerror(addr_info_result));
     return false;
   }
 
@@ -92,9 +92,9 @@ bool TCPSocket::setup(std::string& host, int port)
       continue;
     }
 
-    if (open(socket_fd_, p->ai_addr, p->ai_addrlen) == -1)
+    if (!open(socket_fd_, p->ai_addr, p->ai_addrlen))
     {
-      LOG_ERROR("open() error: %s", strerror(errno));
+      LOG_WARN("Unable to open socket %s:%d", host.c_str(), port);
       ::close(socket_fd_);
       continue;
     }


### PR DESCRIPTION
- Seeing unexplained socket issues (see [this bug](https://www.notion.so/chefrobotics/Stuck-in-INIT-arm-is-not-connected-43eec86fd8e04849b51ee50ca6f9b2ce)).
- This PR adds some additional error logging to the socket setup function used by the TCPClient class used in the driver.

Testing:
[x] On hw; cause some socket chaos; ensure socket errors are logged.