### PR TITLE
:writing_hand: Publish protective stop "ratios"

### DIFF
--- a/ur_extra_msgs/msg/ProtectiveStopRatios.msg
+++ b/ur_extra_msgs/msg/ProtectiveStopRatios.msg
@@ -1,7 +1,10 @@
 # Data regarding how "close" the robot is to triggering particular protective stop related faults.
-# The ratios are non-negative; a protective stop is triggered if the value of a ratio is >= 1.0.
+# The ratios are non-negative (unless unknown); a protective stop is triggered if the value of a
+# ratio is >= 1.0.
 
 Header header
+
+float64 UNKNOWN_RATIO=-1.0  # Sentinel value for "unknown ratio".
 
 # How close the robot is to triggering a C157 or C158 "collision detected" protective stop.
 # Introduced in Polyscope 5.15.0; see:

--- a/ur_extra_msgs/msg/ProtectiveStopRatios.msg
+++ b/ur_extra_msgs/msg/ProtectiveStopRatios.msg
@@ -1,10 +1,7 @@
 # Data regarding how "close" the robot is to triggering particular protective stop related faults.
-# The ratios are non-negative (unless unknown); a protective stop is triggered if the value of a
-# ratio is ever equal to or exceeds 1.0.
+# The ratios are non-negative; a protective stop is triggered if the value of a ratio is >= 1.0.
 
 Header header
-
-float64 UNKNOWN_RATIO=-1.0  # Sentinel value for "unknown ratio".
 
 # How close the robot is to triggering a C157 or C158 "collision detected" protective stop.
 # Introduced in Polyscope 5.15.0; see:

--- a/ur_extra_msgs/msg/ProtectiveStopRatios.msg
+++ b/ur_extra_msgs/msg/ProtectiveStopRatios.msg
@@ -1,0 +1,16 @@
+# Data regarding how "close" the robot is to triggering particular protective stop related faults.
+# The ratios are non-negative (unless unknown); a protective stop is triggered if the value of a
+# ratio is ever equal to or exceeds 1.0.
+
+Header header
+
+float64 UNKNOWN_RATIO=-1.0  # Sentinel value for "unknown ratio".
+
+# How close the robot is to triggering a C157 or C158 "collision detected" protective stop.
+# Introduced in Polyscope 5.15.0; see:
+# https://www.universal-robots.com/articles/ur/release-notes/release-note-software-version-515xx/
+float64 collision_detection_ratio
+
+# How close the robot is to triggering a C153 or C159 "joint position deviation" protective stop.
+# No documentation on when this was introduced; assuming it has always been there.
+float64 joint_position_deviation_ratio

--- a/ur_robot_driver/include/ur_robot_driver/ros/hardware_interface.h
+++ b/ur_robot_driver/include/ur_robot_driver/ros/hardware_interface.h
@@ -203,7 +203,8 @@ protected:
   bool stopControl(std_srvs::TriggerRequest& req, std_srvs::TriggerResponse& res);
 
   template <typename T>
-  void readData(const std::unique_ptr<rtde_interface::DataPackage>& data_pkg, const std::string& var_name, T& data);
+  void readData(const std::unique_ptr<rtde_interface::DataPackage>& data_pkg, const std::string& var_name, T& data,
+                bool throw_on_error = true, const T& default_value = T{});
   template <typename T, size_t N>
   void readBitsetData(const std::unique_ptr<rtde_interface::DataPackage>& data_pkg, const std::string& var_name,
                       std::bitset<N>& data);

--- a/ur_robot_driver/include/ur_robot_driver/ros/hardware_interface.h
+++ b/ur_robot_driver/include/ur_robot_driver/ros/hardware_interface.h
@@ -46,6 +46,7 @@
 #include "ur_msgs/SetSpeedSliderFraction.h"
 
 #include <ur_extra_msgs/JointTemperatures.h>
+#include <ur_extra_msgs/ProtectiveStopRatios.h>
 
 #include <ur_controllers/speed_scaling_interface.h>
 #include <ur_controllers/scaled_joint_command_interface.h>
@@ -191,6 +192,7 @@ protected:
   void publishToolData();
   void publishRobotAndSafetyMode();
   void publishJointTemperatures(const ros::Time& timestamp);
+  void publishProtectiveStopRatios(const ros::Time& timestamp);
 
   /*!
    * \brief Read and evaluate data in order to set robot status properties for industrial
@@ -265,6 +267,7 @@ protected:
   int32_t safety_mode_;
   std::bitset<4> robot_status_bits_;
   std::bitset<11> safety_status_bits_;
+  double joint_position_deviation_ratio_;
 
   std::unique_ptr<realtime_tools::RealtimePublisher<tf2_msgs::TFMessage>> tcp_pose_pub_;
   std::unique_ptr<realtime_tools::RealtimePublisher<ur_msgs::IOStates>> io_pub_;
@@ -272,6 +275,7 @@ protected:
   std::unique_ptr<realtime_tools::RealtimePublisher<ur_dashboard_msgs::RobotMode>> robot_mode_pub_;
   std::unique_ptr<realtime_tools::RealtimePublisher<ur_dashboard_msgs::SafetyMode>> safety_mode_pub_;
   std::unique_ptr<realtime_tools::RealtimePublisher<ur_extra_msgs::JointTemperatures>> joint_temperatures_pub_;
+  std::unique_ptr<realtime_tools::RealtimePublisher<ur_extra_msgs::ProtectiveStopRatios>> pstop_ratios_pub_;
 
   ros::ServiceServer set_speed_slider_srv_;
   ros::ServiceServer set_io_srv_;

--- a/ur_robot_driver/include/ur_robot_driver/ros/hardware_interface.h
+++ b/ur_robot_driver/include/ur_robot_driver/ros/hardware_interface.h
@@ -268,6 +268,7 @@ protected:
   std::bitset<4> robot_status_bits_;
   std::bitset<11> safety_status_bits_;
   double joint_position_deviation_ratio_;
+  double collision_detection_ratio_;
 
   std::unique_ptr<realtime_tools::RealtimePublisher<tf2_msgs::TFMessage>> tcp_pose_pub_;
   std::unique_ptr<realtime_tools::RealtimePublisher<ur_msgs::IOStates>> io_pub_;

--- a/ur_robot_driver/resources/rtde_output_recipe.txt
+++ b/ur_robot_driver/resources/rtde_output_recipe.txt
@@ -27,3 +27,4 @@ safety_status_bits
 actual_current
 joint_temperatures
 joint_position_deviation_ratio
+collision_detection_ratio

--- a/ur_robot_driver/resources/rtde_output_recipe.txt
+++ b/ur_robot_driver/resources/rtde_output_recipe.txt
@@ -26,3 +26,4 @@ robot_status_bits
 safety_status_bits
 actual_current
 joint_temperatures
+joint_position_deviation_ratio

--- a/ur_robot_driver/resources/rtde_output_recipe.txt
+++ b/ur_robot_driver/resources/rtde_output_recipe.txt
@@ -1,3 +1,6 @@
+# NB: Unless otherwise noted, all variables are available in Polyscope >= 5.0.0
+# The driver does NOT check the compatibility of the recipe variables against
+# the Polyscope version and will just error out if there is an incompatibility.
 timestamp
 actual_q
 actual_qd
@@ -27,4 +30,4 @@ safety_status_bits
 actual_current
 joint_temperatures
 joint_position_deviation_ratio
-collision_detection_ratio
+collision_detection_ratio # Introduced in Polyscope 5.15.0

--- a/ur_robot_driver/resources/rtde_output_recipe.txt
+++ b/ur_robot_driver/resources/rtde_output_recipe.txt
@@ -1,6 +1,6 @@
 # NB: Unless otherwise noted, all variables are available in Polyscope >= 5.0.0
-# The driver does NOT check the compatibility of the recipe variables against
-# the Polyscope version and will just error out if there is an incompatibility.
+# The driver does NOT resolve incompatibilities between recipe variables and
+# Polyscope version; it will just error out (see `RTDEClient::setupOutputs()`).
 timestamp
 actual_q
 actual_qd
@@ -30,4 +30,6 @@ safety_status_bits
 actual_current
 joint_temperatures
 joint_position_deviation_ratio
-collision_detection_ratio # Introduced in Polyscope 5.15.0
+# Introduced in Polyscope 5.15.0
+# Commented out since the Polyscope version being used is unknown
+# collision_detection_ratio

--- a/ur_robot_driver/src/ros/hardware_interface.cpp
+++ b/ur_robot_driver/src/ros/hardware_interface.cpp
@@ -758,7 +758,6 @@ void HardwareInterface::publishProtectiveStopRatios(const ros::Time& timestamp)
     if (pstop_ratios_pub_->trylock())
     {
       pstop_ratios_pub_->msg_.header.stamp = timestamp;
-      // TODO(cj): Add logic to check the Polyscope version running and publish collision_detection_ratio if possible.
       pstop_ratios_pub_->msg_.collision_detection_ratio = collision_detection_ratio_;
       pstop_ratios_pub_->msg_.joint_position_deviation_ratio = joint_position_deviation_ratio_;
       pstop_ratios_pub_->unlockAndPublish();

--- a/ur_robot_driver/src/ros/hardware_interface.cpp
+++ b/ur_robot_driver/src/ros/hardware_interface.cpp
@@ -478,6 +478,7 @@ void HardwareInterface::read(const ros::Time& time, const ros::Duration& period)
     readBitsetData<uint32_t>(data_pkg, "tool_analog_input_types", tool_analog_input_types_);
     readData(data_pkg, "joint_temperatures", joint_temperatures_);
     readData(data_pkg, "joint_position_deviation_ratio", joint_position_deviation_ratio_);
+    readData(data_pkg, "collision_detection_ratio", collision_detection_ratio_);
 
     extractRobotStatus();
 
@@ -757,11 +758,8 @@ void HardwareInterface::publishProtectiveStopRatios(const ros::Time& timestamp)
     if (pstop_ratios_pub_->trylock())
     {
       pstop_ratios_pub_->msg_.header.stamp = timestamp;
-      /* N.B. We set `collision_detection_ratio` to "unknown" since we haven't yet implemented the logic to know if this
-       * value is available over RTDE (only available when running Polyscope >= 5.15.0).
-       */
       // TODO(cj): Add logic to check the Polyscope version running and publish collision_detection_ratio if possible.
-      pstop_ratios_pub_->msg_.collision_detection_ratio = ur_extra_msgs::ProtectiveStopRatios::UNKNOWN_RATIO;
+      pstop_ratios_pub_->msg_.collision_detection_ratio = collision_detection_ratio_;
       pstop_ratios_pub_->msg_.joint_position_deviation_ratio = joint_position_deviation_ratio_;
       pstop_ratios_pub_->unlockAndPublish();
     }

--- a/ur_robot_driver/src/rtde/data_package.cpp
+++ b/ur_robot_driver/src/rtde/data_package.cpp
@@ -68,6 +68,7 @@ std::unordered_map<std::string, DataPackage::_rtde_type_variant> DataPackage::g_
   { "elbow_velocity", vector3d_t() },
   { "robot_status_bits", uint32_t() },
   { "safety_status_bits", uint32_t() },
+  { "joint_position_deviation_ratio", double() },
   { "analog_io_types", uint32_t() },
   { "standard_analog_input0", double() },
   { "standard_analog_input1", double() },

--- a/ur_robot_driver/src/rtde/data_package.cpp
+++ b/ur_robot_driver/src/rtde/data_package.cpp
@@ -69,6 +69,7 @@ std::unordered_map<std::string, DataPackage::_rtde_type_variant> DataPackage::g_
   { "robot_status_bits", uint32_t() },
   { "safety_status_bits", uint32_t() },
   { "joint_position_deviation_ratio", double() },
+  { "collision_detection_ratio", double() },
   { "analog_io_types", uint32_t() },
   { "standard_analog_input0", double() },
   { "standard_analog_input1", double() },

--- a/ur_robot_driver/src/rtde/rtde_client.cpp
+++ b/ur_robot_driver/src/rtde/rtde_client.cpp
@@ -333,7 +333,19 @@ std::vector<std::string> RTDEClient::readRecipe(const std::string& recipe_file)
   std::string line;
   while (std::getline(file, line))
   {
-    recipe.push_back(line);
+    // Handle comments (denoted by a hashtag '#')
+    std::size_t pos = line.find('#');
+    if (pos != std::string::npos)
+    {
+      // Truncate the line at the position of the first hashtag
+      line = line.substr(0, pos);
+    }
+    // Trim any leading or trailing whitespace
+    line.erase(line.find_last_not_of(" \n\r\t") + 1);
+    if (!line.empty()) // Only add non-empty lines
+    {
+      recipe.push_back(line);
+    }
   }
   return recipe;
 }

--- a/ur_robot_driver/src/rtde/rtde_client.cpp
+++ b/ur_robot_driver/src/rtde/rtde_client.cpp
@@ -65,6 +65,10 @@ bool RTDEClient::init()
   LOG_INFO("Negotiated RTDE protocol version to %hu.", protocol_version);
   parser_.setProtocolVersion(protocol_version);
 
+  /* TODO(cj): It would be great to adjust the input and output recipes according to the Polyscope version,
+   *   but they have already been loaded in the constructor and would be a pain to modify post-facto.
+   *   Should consider delaying loading of the recipe until the Polyscope version can be checked for compatibility.
+   */
   queryURControlVersion();
   if (urcontrol_version_.major < 5)
   {


### PR DESCRIPTION
This PR updates the driver to retrieve the "protective stop ratios" (over RTDE) and then publish them.

See [here](https://www.universal-robots.com/articles/ur/interface-communication/real-time-data-exchange-rtde-guide/) and [here](https://www.universal-robots.com/articles/ur/release-notes/release-note-software-version-515xx/) for info the pstop ratios.

The data is published on a new topic, `<ns>/ur_hardware_interface/protective_stop_ratios`.

In addition, a small feature was added to allow for comments -- denoted by `#` -- in rtde recipe text files.

One of the ratios -- `collision_detection_ratio` -- was introduced in Polyscope 5.15.0. However, we can't guarantee that every robot will be running with Polyscope >= 5.15.0. At the moment, specifying this ratio as an rtde output would result in a driver error if running with Polyscope < 5.15.0 (see comment in `rtde_client.cpp`), so it is commented out in the default output recipe. We could try to work around this in the driver -- namely, do the `TODO` that was left in `rtde_client.cpp` -- but this would require a larger rework of the RTDE pipeline than I would like; instead, this will be handled upstream by checking Polyscope version during launch and passing a compatible output recipe file (for now, the default output is always used, and we want that to be compatible with all Polyscope versions, hence why `collision_detection_ratio` is commented out).

# Testing
- [x] Run on module with Polyscope < 5.15.0; ensure no issue and `ur_hardware_interface/protective_stop_ratios` is being published with expected data.
- [x] Run on module with Polyscope >= 5.15.0; ensure no issue and `ur_hardware_interface/protective_stop_ratios` is being published with expected data.
- [x] Run on module with Polyscope >= 5.15.0 and uncomment `collision_detection_ratio` in the rtde output recipe; ensure no issue and `ur_hardware_interface/protective_stop_ratios` is being published with expected data.