### PR TITLE
:writing_hand: :tada: Publish `JointStateExtended`

### DIFF
--- a/ur_extra_msgs/msg/JointStateExtended.msg
+++ b/ur_extra_msgs/msg/JointStateExtended.msg
@@ -1,58 +1,45 @@
-# Similar to sensor_msgs/JointState, but with more fields.
-# TODO(cj): Should probably add `has_*` flags / sentinel values.
+# Similar to sensor_msgs/JointState, but with more fields
 
-# Meta data
-#
+# Metadata
 # `stamp` corresponds to the time when the state was recorded.
 Header header
 # NB: The order in all other lists follows the order of `names`.
 string[] names
 
 # Position data [rad]
-#
-# RTDE `target_q`
+# RTDE 'target_q'
 float64[] target_positions
-# RTDE `actual_q`
+# RTDE 'actual_q'
 float64[] actual_positions
 
 # Velocity data [rad/s]
-#
-# RTDE `target_qd`
+# RTDE 'target_qd'
 float64[] target_velocities
-# RTDE `actual_qd`
+# RTDE 'actual_qd'
 float64[] actual_velocities
 
 # Acceleration data [rad/s^2]
-#
-# RTDE `target_qdd`
+# RTDE 'target_qdd'  (only target available)
 float64[] target_accelerations
-# RTDE `actual_qdd` -- possibly unavailable?
-float64[] actual_accelerations
 
-# Current data [mA]
-#
-# RTDE `target_current`
+# Current data [A]
+# RTDE 'target_current'
 float64[] target_currents
-# RTDE `actual_current`
+# RTDE 'actual_current'
 float64[] actual_currents
-# RTDE `actual_current_window`
+# RTDE 'actual_current_window'
 float64[] actual_current_windows
-# RTDE `joint_control_output` -- possibly same as `actual_current`?
-float64[] joint_control_outputs
 
-# Voltage data [V]: RTDE `actual_joint_voltage`
+# Voltage data [V]
+# RTDE 'actual_joint_voltage' (no target voltage)
 float64[] actual_voltages
 
 # Torque data [Nm]
-#
-# RTDE `target_moment`
+# RTDE 'target_moment'  (only target available)
 float64[] target_torques
-# RTDE `actual_moment` -- possibly unavailable?
-float64[] actual_torques
 
 # Contextual data
-#
-# Temperature [C]: RTDE `joint_temperatures`
-float64[] temperatures
-# Mode: RTDE `joint_mode`
+# RTDE 'joint_mode'
 int32[] control_modes
+# RTDE 'joint_control_output' (typically the same as 'actual_current')
+float64[] joint_control_outputs

--- a/ur_extra_msgs/msg/JointStateExtended.msg
+++ b/ur_extra_msgs/msg/JointStateExtended.msg
@@ -8,19 +8,19 @@ string[] names
 
 # Position data [rad]
 # RTDE 'target_q'
-float64[] target_positions
+# float64[] target_positions
 # RTDE 'actual_q'
-float64[] actual_positions
+# float64[] actual_positions
 
 # Velocity data [rad/s]
 # RTDE 'target_qd'
-float64[] target_velocities
+# float64[] target_velocities
 # RTDE 'actual_qd'
-float64[] actual_velocities
+# float64[] actual_velocities
 
 # Acceleration data [rad/s^2]
 # RTDE 'target_qdd' (only target available)
-float64[] target_accelerations
+# float64[] target_accelerations
 
 # Current data [A]
 # RTDE 'target_current'

--- a/ur_extra_msgs/msg/JointStateExtended.msg
+++ b/ur_extra_msgs/msg/JointStateExtended.msg
@@ -6,21 +6,9 @@ Header header
 # NB: The order in all other lists follows the order of `names`.
 string[] names
 
-# Position data [rad]
-# RTDE 'target_q'
-# float64[] target_positions
-# RTDE 'actual_q'
-# float64[] actual_positions
-
-# Velocity data [rad/s]
-# RTDE 'target_qd'
-# float64[] target_velocities
-# RTDE 'actual_qd'
-# float64[] actual_velocities
-
-# Acceleration data [rad/s^2]
-# RTDE 'target_qdd' (only target available)
-# float64[] target_accelerations
+# For target / actual positions, target / actual actual_velocities,
+# and target accelerations, refer to the state output message
+# of the controller, which is published with the same header stamp.
 
 # Current data [A]
 # RTDE 'target_current'

--- a/ur_extra_msgs/msg/JointStateExtended.msg
+++ b/ur_extra_msgs/msg/JointStateExtended.msg
@@ -28,6 +28,6 @@ float64[] target_torques
 
 # Contextual data
 # RTDE 'joint_mode'
-int32[] control_modes
+int32[] joint_control_modes
 # RTDE 'joint_control_output' (typically the same as 'actual_current')
 float64[] joint_control_outputs

--- a/ur_extra_msgs/msg/JointStateExtended.msg
+++ b/ur_extra_msgs/msg/JointStateExtended.msg
@@ -1,0 +1,57 @@
+# Similar to sensor_msgs/JointState, but with more fields.
+
+# Meta data
+#
+# `stamp` corresponds to the time when the state was recorded.
+Header header
+# NB: The order in all other lists follows the order of `names`.
+string[] names
+
+# Position data [rad]
+#
+# RTDE `target_q`
+float64[] target_positions
+# RTDE `actual_q`
+float64[] actual_positions
+
+# Velocity data [rad/s]
+#
+# RTDE `target_qd`
+float64[] target_velocities
+# RTDE `actual_qd`
+float64[] actual_velocities
+
+# Acceleration data [rad/s^2]
+#
+# RTDE `target_qdd`
+float64[] target_accelerations
+# RTDE `actual_qdd` -- possibly unavailable?
+float64[] actual_accelerations
+
+# Current data [mA]
+#
+# RTDE `target_current`
+float64[] target_currents
+# RTDE `actual_current`
+float64[] actual_currents
+# RTDE `actual_current_window`
+float64[] actual_current_windows
+# RTDE `joint_control_output` -- possibly same as `actual_current`?
+float64[] joint_control_currents
+
+# Voltage data [V]: RTDE `actual_joint_voltages`
+float64[] actual_voltages
+
+# Torque data [Nm]
+#
+# RTDE `target_moment`
+float64[] target_torques
+# RTDE `actual_moment` -- possibly unavailable?
+float64[] actual_torques
+
+# Contextual data
+#
+# Temperature [C]: RTDE `joint_temperatures`
+float64[] temperatures
+# Mode: RTDE `joint_mode`
+int32[] control_modes

--- a/ur_extra_msgs/msg/JointStateExtended.msg
+++ b/ur_extra_msgs/msg/JointStateExtended.msg
@@ -1,4 +1,5 @@
 # Similar to sensor_msgs/JointState, but with more fields.
+# TODO(cj): Should probably add `has_*` flags / sentinel values.
 
 # Meta data
 #
@@ -37,9 +38,9 @@ float64[] actual_currents
 # RTDE `actual_current_window`
 float64[] actual_current_windows
 # RTDE `joint_control_output` -- possibly same as `actual_current`?
-float64[] joint_control_currents
+float64[] joint_control_outputs
 
-# Voltage data [V]: RTDE `actual_joint_voltages`
+# Voltage data [V]: RTDE `actual_joint_voltage`
 float64[] actual_voltages
 
 # Torque data [Nm]

--- a/ur_extra_msgs/msg/JointStateExtended.msg
+++ b/ur_extra_msgs/msg/JointStateExtended.msg
@@ -19,7 +19,7 @@ float64[] target_velocities
 float64[] actual_velocities
 
 # Acceleration data [rad/s^2]
-# RTDE 'target_qdd'  (only target available)
+# RTDE 'target_qdd' (only target available)
 float64[] target_accelerations
 
 # Current data [A]
@@ -35,7 +35,7 @@ float64[] actual_current_windows
 float64[] actual_voltages
 
 # Torque data [Nm]
-# RTDE 'target_moment'  (only target available)
+# RTDE 'target_moment' (only target available)
 float64[] target_torques
 
 # Contextual data

--- a/ur_extra_msgs/msg/ProtectiveStopRatios.msg
+++ b/ur_extra_msgs/msg/ProtectiveStopRatios.msg
@@ -15,6 +15,8 @@ float64 collision_detection_ratio
 # No documentation on when this was introduced; assuming it has always been there.
 float64 joint_position_deviation_ratio
 
-# RTDE `time_scale_source`
+# RTDE 'time_scale_source'
 # Introduced in Polyscope 5.17.0
+# See the RTDE guide for a breakdown of the values:
+# https://www.universal-robots.com/articles/ur/interface-communication/real-time-data-exchange-rtde-guide/
 int32 time_scale_source

--- a/ur_extra_msgs/msg/ProtectiveStopRatios.msg
+++ b/ur_extra_msgs/msg/ProtectiveStopRatios.msg
@@ -14,3 +14,7 @@ float64 collision_detection_ratio
 # How close the robot is to triggering a C153 or C159 "joint position deviation" protective stop.
 # No documentation on when this was introduced; assuming it has always been there.
 float64 joint_position_deviation_ratio
+
+# RTDE `time_scale_source`
+# Introduced in Polyscope 5.17.0
+int32 time_scale_source

--- a/ur_robot_driver/include/ur_robot_driver/ros/hardware_interface.h
+++ b/ur_robot_driver/include/ur_robot_driver/ros/hardware_interface.h
@@ -283,6 +283,7 @@ protected:
   std::bitset<11> safety_status_bits_;
   double joint_position_deviation_ratio_;
   double collision_detection_ratio_;
+  int32_t time_scale_source_;
 
   std::unique_ptr<realtime_tools::RealtimePublisher<tf2_msgs::TFMessage>> tcp_pose_pub_;
   std::unique_ptr<realtime_tools::RealtimePublisher<ur_msgs::IOStates>> io_pub_;

--- a/ur_robot_driver/include/ur_robot_driver/ros/hardware_interface.h
+++ b/ur_robot_driver/include/ur_robot_driver/ros/hardware_interface.h
@@ -242,15 +242,8 @@ protected:
 
   vector6d_t joint_position_command_;
   vector6d_t joint_velocity_command_;
-  vector6d_t target_joint_positions_;
-  bool has_target_joint_positions_{false};
   vector6d_t joint_positions_;
-  vector6d_t target_joint_velocities_;
-  bool has_target_joint_velocities_{false};
   vector6d_t joint_velocities_;
-  vector6d_t target_joint_accelerations_;
-  bool has_target_joint_accelerations_{false};
-  vector6d_t joint_accelerations_;
   vector6d_t target_joint_efforts_;
   bool has_target_joint_efforts_{false};
   vector6d_t joint_efforts_;

--- a/ur_robot_driver/include/ur_robot_driver/ros/hardware_interface.h
+++ b/ur_robot_driver/include/ur_robot_driver/ros/hardware_interface.h
@@ -205,7 +205,7 @@ protected:
   bool stopControl(std_srvs::TriggerRequest& req, std_srvs::TriggerResponse& res);
 
   template <typename T>
-  void readData(const std::unique_ptr<rtde_interface::DataPackage>& data_pkg, const std::string& var_name, T& data,
+  bool readData(const std::unique_ptr<rtde_interface::DataPackage>& data_pkg, const std::string& var_name, T& data,
                 bool throw_on_error = true, const T& default_value = T{});
   template <typename T, size_t N>
   void readBitsetData(const std::unique_ptr<rtde_interface::DataPackage>& data_pkg, const std::string& var_name,
@@ -243,19 +243,27 @@ protected:
   vector6d_t joint_position_command_;
   vector6d_t joint_velocity_command_;
   vector6d_t target_joint_positions_;
+  bool has_target_joint_positions_{false};
   vector6d_t joint_positions_;
   vector6d_t target_joint_velocities_;
+  bool has_target_joint_velocities_{false};
   vector6d_t joint_velocities_;
   vector6d_t target_joint_accelerations_;
+  bool has_target_joint_accelerations_{false};
   vector6d_t joint_accelerations_;
   vector6d_t target_joint_efforts_;
+  bool has_target_joint_efforts_{false};
   vector6d_t joint_efforts_;
   vector6d_t joint_current_windows_;
+  bool has_joint_current_windows_{false};
   vector6d_t target_joint_moments_;
-  vector6d_t joint_moments_;
+  bool has_target_joint_moments_{false};
   vector6d_t joint_control_outputs_;
+  bool has_joint_control_outputs_{false};
   vector6d_t joint_temperatures_;
+  bool has_joint_temperatures_{false};
   vector6d_t joint_voltages_;
+  bool has_joint_voltages_{false};
   vector6d_t fts_measurements_;
   vector6d_t tcp_pose_;
   std::bitset<18> actual_dig_out_bits_;
@@ -278,6 +286,7 @@ protected:
   std::vector<std::string> joint_names_;
   int32_t robot_mode_;
   vector6int32_t joint_control_modes_;
+  bool has_joint_control_modes_{false};
   int32_t safety_mode_;
   std::bitset<4> robot_status_bits_;
   std::bitset<11> safety_status_bits_;

--- a/ur_robot_driver/include/ur_robot_driver/ros/hardware_interface.h
+++ b/ur_robot_driver/include/ur_robot_driver/ros/hardware_interface.h
@@ -277,7 +277,7 @@ protected:
   double speed_scaling_combined_;
   std::vector<std::string> joint_names_;
   int32_t robot_mode_;
-  vector6int32_t joint_modes_;
+  vector6int32_t joint_control_modes_;
   int32_t safety_mode_;
   std::bitset<4> robot_status_bits_;
   std::bitset<11> safety_status_bits_;

--- a/ur_robot_driver/include/ur_robot_driver/ros/hardware_interface.h
+++ b/ur_robot_driver/include/ur_robot_driver/ros/hardware_interface.h
@@ -47,6 +47,7 @@
 
 #include <ur_extra_msgs/JointTemperatures.h>
 #include <ur_extra_msgs/ProtectiveStopRatios.h>
+#include <ur_extra_msgs/JointStateExtended.h>
 
 #include <ur_controllers/speed_scaling_interface.h>
 #include <ur_controllers/scaled_joint_command_interface.h>
@@ -193,6 +194,7 @@ protected:
   void publishRobotAndSafetyMode();
   void publishJointTemperatures(const ros::Time& timestamp);
   void publishProtectiveStopRatios(const ros::Time& timestamp);
+  void publishJointStateExtended(const ros::Time& timestamp);
 
   /*!
    * \brief Read and evaluate data in order to set robot status properties for industrial
@@ -240,10 +242,20 @@ protected:
 
   vector6d_t joint_position_command_;
   vector6d_t joint_velocity_command_;
+  vector6d_t target_joint_positions_;
   vector6d_t joint_positions_;
+  vector6d_t target_joint_velocities_;
   vector6d_t joint_velocities_;
+  vector6d_t target_joint_accelerations_;
+  vector6d_t joint_accelerations_;
+  vector6d_t target_joint_efforts_;
   vector6d_t joint_efforts_;
+  vector6d_t joint_current_windows_;
+  vector6d_t target_joint_moments_;
+  vector6d_t joint_moments_;
+  vector6d_t joint_control_outputs_;
   vector6d_t joint_temperatures_;
+  vector6d_t joint_voltages_;
   vector6d_t fts_measurements_;
   vector6d_t tcp_pose_;
   std::bitset<18> actual_dig_out_bits_;
@@ -265,6 +277,7 @@ protected:
   double speed_scaling_combined_;
   std::vector<std::string> joint_names_;
   int32_t robot_mode_;
+  vector6int32_t joint_modes_;
   int32_t safety_mode_;
   std::bitset<4> robot_status_bits_;
   std::bitset<11> safety_status_bits_;
@@ -278,6 +291,7 @@ protected:
   std::unique_ptr<realtime_tools::RealtimePublisher<ur_dashboard_msgs::SafetyMode>> safety_mode_pub_;
   std::unique_ptr<realtime_tools::RealtimePublisher<ur_extra_msgs::JointTemperatures>> joint_temperatures_pub_;
   std::unique_ptr<realtime_tools::RealtimePublisher<ur_extra_msgs::ProtectiveStopRatios>> pstop_ratios_pub_;
+  std::unique_ptr<realtime_tools::RealtimePublisher<ur_extra_msgs::JointStateExtended>> joint_state_extended_pub_;
 
   ros::ServiceServer set_speed_slider_srv_;
   ros::ServiceServer set_io_srv_;

--- a/ur_robot_driver/src/ros/hardware_interface.cpp
+++ b/ur_robot_driver/src/ros/hardware_interface.cpp
@@ -50,10 +50,21 @@ static const std::bitset<11> in_error_bitset_(1 << toUnderlying(UrRtdeSafetyStat
 HardwareInterface::HardwareInterface()
   : joint_position_command_({ 0, 0, 0, 0, 0, 0 })
   , joint_velocity_command_({ 0, 0, 0, 0, 0, 0 })
+  , target_joint_positions_{ { 0, 0, 0, 0, 0, 0 } }
   , joint_positions_{ { 0, 0, 0, 0, 0, 0 } }
+  , target_joint_velocities_{ { 0, 0, 0, 0, 0, 0 } }
   , joint_velocities_{ { 0, 0, 0, 0, 0, 0 } }
+  , target_joint_accelerations_{ { 0, 0, 0, 0, 0, 0 } }
+  , joint_accelerations_{ { 0, 0, 0, 0, 0, 0 } }
+  , target_joint_efforts_{ { 0, 0, 0, 0, 0, 0 } }
   , joint_efforts_{ { 0, 0, 0, 0, 0, 0 } }
+  , joint_current_windows_{ { 0, 0, 0, 0, 0, 0 } }
+  , target_joint_moments_{ { 0, 0, 0, 0, 0, 0 } }
+  , joint_moments_{ { 0, 0, 0, 0, 0, 0 } }
+  , joint_control_outputs_{ { 0, 0, 0, 0, 0, 0 } }
+  , joint_voltages_{ { 0, 0, 0, 0, 0, 0 } }
   , joint_temperatures_{ { 0, 0, 0, 0, 0, 0 } }
+  , joint_modes_{ { 0, 0, 0, 0, 0, 0 } }
   , standard_analog_input_{ { 0, 0 } }
   , standard_analog_output_{ { 0, 0 } }
   , joint_names_(6)
@@ -364,6 +375,8 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
   pstop_ratios_pub_.reset(
       new realtime_tools::RealtimePublisher<ur_extra_msgs::ProtectiveStopRatios>(robot_hw_nh, "protective_stop_ratios",
                                                                                  1));
+  joint_state_extended_pub_.reset(
+      new realtime_tools::RealtimePublisher<ur_extra_msgs::JointStateExtended>(robot_hw_nh, "joint_state_extended", 1));
 
   // Set the speed slider fraction used by the robot's execution. Values should be between 0 and 1.
   // Only set this smaller than 1 if you are using the scaled controllers (as by default) or you know what you're
@@ -457,8 +470,20 @@ void HardwareInterface::read(const ros::Time& time, const ros::Duration& period)
   if (data_pkg)
   {
     packet_read_ = true;
+    readData(data_pkg, "target_q", target_joint_positions_);
+    readData(data_pkg, "target_qd", target_joint_velocities_);
+    readData(data_pkg, "target_qdd", target_joint_accelerations_);
+    readData(data_pkg, "target_current", target_joint_efforts_);
+    readData(data_pkg, "target_moment", target_joint_moments_);
     readData(data_pkg, "actual_q", joint_positions_);
     readData(data_pkg, "actual_qd", joint_velocities_);
+    readData(data_pkg, "actual_qdd", joint_accelerations_);
+    readData(data_pkg, "actual_current", joint_efforts_);
+    readData(data_pkg, "actual_current_window", joint_current_windows_);
+    readData(data_pkg, "actual_moment", joint_moments_);
+    readData(data_pkg, "joint_control_output", joint_control_outputs_);
+    readData(data_pkg, "joint_temperatures", joint_temperatures_);
+    readData(data_pkg, "actual_joint_voltage", joint_voltages_);
     readData(data_pkg, "target_speed_fraction", target_speed_fraction_);
     readData(data_pkg, "speed_scaling", speed_scaling_);
     readData(data_pkg, "runtime_state", runtime_state_);
@@ -475,15 +500,14 @@ void HardwareInterface::read(const ros::Time& time, const ros::Duration& period)
     readData(data_pkg, "tool_output_current", tool_output_current_);
     readData(data_pkg, "tool_temperature", tool_temperature_);
     readData(data_pkg, "robot_mode", robot_mode_);
+    readData(data_pkg, "joint_mode", joint_modes_);
     readData(data_pkg, "safety_mode", safety_mode_);
     readBitsetData<uint32_t>(data_pkg, "robot_status_bits", robot_status_bits_);
     readBitsetData<uint32_t>(data_pkg, "safety_status_bits", safety_status_bits_);
-    readData(data_pkg, "actual_current", joint_efforts_);
     readBitsetData<uint64_t>(data_pkg, "actual_digital_input_bits", actual_dig_in_bits_);
     readBitsetData<uint64_t>(data_pkg, "actual_digital_output_bits", actual_dig_out_bits_);
     readBitsetData<uint32_t>(data_pkg, "analog_io_types", analog_io_types_);
     readBitsetData<uint32_t>(data_pkg, "tool_analog_input_types", tool_analog_input_types_);
-    readData(data_pkg, "joint_temperatures", joint_temperatures_);
     readData(data_pkg, "joint_position_deviation_ratio", joint_position_deviation_ratio_, false,
              ur_extra_msgs::ProtectiveStopRatios::UNKNOWN_RATIO);
     readData(data_pkg, "collision_detection_ratio", collision_detection_ratio_, false,
@@ -499,6 +523,7 @@ void HardwareInterface::read(const ros::Time& time, const ros::Duration& period)
     transformForceTorque();
     publishPose();
     publishRobotAndSafetyMode();
+    publishJointStateExtended(time);
     publishProtectiveStopRatios(time);
     if (this->enable_temperature_log_) {
       publishJointTemperatures(time);
@@ -773,6 +798,78 @@ void HardwareInterface::publishProtectiveStopRatios(const ros::Time& timestamp)
     }
   }
 }
+
+void HardwareInterface::publishJointStateExtended(const ros::Time& timestamp)
+{
+  if (!joint_state_extended_pub_)
+    return;
+
+  if (!joint_state_extended_pub_->trylock())
+    return;
+
+  auto& msg = joint_state_extended_pub_->msg_;
+  msg.header.stamp = timestamp;
+
+  // One-time initialization: copy joint names and pre-size all arrays
+  static bool first_time = true;
+  if (first_time)
+  {
+    const size_t N = joint_names_.size();
+    msg.names = joint_names_;
+
+    msg.target_positions.resize(N);
+    msg.actual_positions.resize(N);
+
+    msg.target_velocities.resize(N);
+    msg.actual_velocities.resize(N);
+
+    msg.target_accelerations.resize(N);
+    msg.actual_accelerations.resize(N);
+
+    msg.target_currents.resize(N);
+    msg.actual_currents.resize(N);
+    msg.actual_current_windows.resize(N);
+    msg.joint_control_outputs.resize(N);
+
+    msg.actual_voltages.resize(N);
+
+    msg.target_torques.resize(N);
+    msg.actual_torques.resize(N);
+
+    msg.temperatures.resize(N);
+    msg.control_modes.resize(N);
+
+    first_time = false;
+  }
+
+  // Fast, deterministic in-place updates every cycle
+  std::copy(target_joint_positions_.begin(),    target_joint_positions_.end(),    msg.target_positions.begin());
+  std::copy(joint_positions_.begin(),           joint_positions_.end(),           msg.actual_positions.begin());
+
+  std::copy(target_joint_velocities_.begin(),   target_joint_velocities_.end(),   msg.target_velocities.begin());
+  std::copy(joint_velocities_.begin(),          joint_velocities_.end(),          msg.actual_velocities.begin());
+
+  std::copy(target_joint_accelerations_.begin(),target_joint_accelerations_.end(),msg.target_accelerations.begin());
+  std::copy(joint_accelerations_.begin(),       joint_accelerations_.end(),       msg.actual_accelerations.begin());
+
+  std::copy(target_joint_efforts_.begin(),      target_joint_efforts_.end(),      msg.target_currents.begin());
+  std::copy(joint_efforts_.begin(),             joint_efforts_.end(),             msg.actual_currents.begin());
+  std::copy(joint_current_windows_.begin(),     joint_current_windows_.end(),     msg.actual_current_windows.begin());
+  std::copy(joint_control_outputs_.begin(),     joint_control_outputs_.end(),     msg.joint_control_outputs.begin());
+
+  std::copy(joint_voltages_.begin(),            joint_voltages_.end(),            msg.actual_voltages.begin());
+
+  std::copy(target_joint_moments_.begin(),      target_joint_moments_.end(),      msg.target_torques.begin());
+  std::copy(joint_moments_.begin(),             joint_moments_.end(),             msg.actual_torques.begin());
+
+  std::copy(joint_temperatures_.begin(),        joint_temperatures_.end(),        msg.temperatures.begin());
+
+  // joint_modes_ is an integer array
+  std::copy(joint_modes_.begin(),               joint_modes_.end(),               msg.control_modes.begin());
+
+  joint_state_extended_pub_->unlockAndPublish();
+}
+
 
 
 void HardwareInterface::extractRobotStatus()

--- a/ur_robot_driver/src/ros/hardware_interface.cpp
+++ b/ur_robot_driver/src/ros/hardware_interface.cpp
@@ -410,22 +410,21 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
 }
 
 template <typename T>
-void HardwareInterface::readData(const std::unique_ptr<rtde_interface::DataPackage>& data_pkg,
+bool HardwareInterface::readData(const std::unique_ptr<rtde_interface::DataPackage>& data_pkg,
                                  const std::string& var_name, T& data, bool throw_on_error, const T& default_value)
 {
-  if (!data_pkg->getData(var_name, data))
+  if (data_pkg->getData(var_name, data))
   {
-    if (throw_on_error)
-    {
-      // This throwing should never happen unless misconfigured
-      std::string error_msg = "Did not find '" + var_name + "' in data sent from robot. This should not happen!";
-      throw std::runtime_error(error_msg);
-    }
-    else
-    {
-      data = default_value;
-    }
+    return true; // actual data arrived
   }
+  if (throw_on_error)
+  {
+    std::string error_msg =
+      "Did not find '" + var_name + "' in data sent from robot. This should not happen!";
+    throw std::runtime_error(error_msg);
+  }
+  data = default_value;
+  return false; // we used the default
 }
 
 template <typename T, size_t N>
@@ -459,17 +458,17 @@ void HardwareInterface::read(const ros::Time& time, const ros::Duration& period)
   if (data_pkg)
   {
     packet_read_ = true;
-    readData(data_pkg, "target_q", target_joint_positions_, false, decltype(target_joint_positions_){});
-    readData(data_pkg, "target_qd", target_joint_velocities_, false, decltype(target_joint_velocities_){});
-    readData(data_pkg, "target_qdd", target_joint_accelerations_, false, decltype(target_joint_accelerations_){});
-    readData(data_pkg, "target_current", target_joint_efforts_, false, decltype(target_joint_efforts_){});
-    readData(data_pkg, "target_moment", target_joint_moments_, false, decltype(target_joint_moments_){});
+    has_target_joint_positions_ = readData(data_pkg, "target_q", target_joint_positions_, false);
+    has_target_joint_velocities_ = readData(data_pkg, "target_qd", target_joint_velocities_, false);
+    has_target_joint_accelerations_ = readData(data_pkg, "target_qdd", target_joint_accelerations_, false);
+    has_target_joint_efforts_ = readData(data_pkg, "target_current", target_joint_efforts_, false);
+    has_target_joint_moments_ = readData(data_pkg, "target_moment", target_joint_moments_, false);
     readData(data_pkg, "actual_q", joint_positions_);
     readData(data_pkg, "actual_qd", joint_velocities_);
     readData(data_pkg, "actual_current", joint_efforts_);
-    readData(data_pkg, "actual_current_window", joint_current_windows_, false, decltype(joint_current_windows_){});
-    readData(data_pkg, "joint_temperatures", joint_temperatures_);
-    readData(data_pkg, "actual_joint_voltage", joint_voltages_, false, decltype(joint_voltages_){});
+    has_joint_current_windows_ = readData(data_pkg, "actual_current_window", joint_current_windows_, false);
+    has_joint_temperatures_ = readData(data_pkg, "joint_temperatures", joint_temperatures_, false);
+    has_joint_voltages_ = readData(data_pkg, "actual_joint_voltage", joint_voltages_, false);
     readData(data_pkg, "target_speed_fraction", target_speed_fraction_);
     readData(data_pkg, "speed_scaling", speed_scaling_);
     readData(data_pkg, "runtime_state", runtime_state_);
@@ -486,8 +485,8 @@ void HardwareInterface::read(const ros::Time& time, const ros::Duration& period)
     readData(data_pkg, "tool_output_current", tool_output_current_);
     readData(data_pkg, "tool_temperature", tool_temperature_);
     readData(data_pkg, "robot_mode", robot_mode_);
-    readData(data_pkg, "joint_mode", joint_control_modes_, false, decltype(joint_control_modes_){});
-    readData(data_pkg, "joint_control_output", joint_control_outputs_, false, decltype(joint_control_outputs_){});
+    has_joint_control_modes_ = readData(data_pkg, "joint_mode", joint_control_modes_, false);
+    has_joint_control_outputs_ = readData(data_pkg, "joint_control_output", joint_control_outputs_, false);
     readData(data_pkg, "safety_mode", safety_mode_);
     readBitsetData<uint32_t>(data_pkg, "robot_status_bits", robot_status_bits_);
     readBitsetData<uint32_t>(data_pkg, "safety_status_bits", safety_status_bits_);
@@ -754,23 +753,32 @@ void HardwareInterface::publishPose()
 
 void HardwareInterface::publishJointTemperatures(const ros::Time& timestamp)
 {
-  if (joint_temperatures_pub_)
+  if (!joint_temperatures_pub_)
+    return;
+  if (!joint_temperatures_pub_->trylock())
+    return;
+
+  auto& msg = joint_temperatures_pub_->msg_;
+  msg.header.stamp = timestamp;
+
+  // One-time setup: reserve capacity for names & temps
+  static bool first_time = true;
+  if (first_time)
   {
-    if (joint_temperatures_pub_->trylock())
-    {
-      joint_temperatures_pub_->msg_.header.stamp = timestamp;
-      joint_temperatures_pub_->msg_.joint_names.clear();
-      joint_temperatures_pub_->msg_.temperatures.clear();
+    const size_t N = joint_names_.size();
+    msg.joint_names = joint_names_;
+    msg.joint_names.reserve(N);
+    msg.temperatures.reserve(N);
 
-      for (size_t i = 0; i < joint_names_.size(); i++)
-      {
-        joint_temperatures_pub_->msg_.joint_names.push_back(joint_names_[i]);
-        joint_temperatures_pub_->msg_.temperatures.push_back(joint_temperatures_[i]);
-      }
-
-      joint_temperatures_pub_->unlockAndPublish();
-    }
+    first_time = false;
   }
+
+  if (has_joint_temperatures_)
+    msg.temperatures.assign(joint_temperatures_.begin(), joint_temperatures_.end());
+  else
+    msg.temperatures.clear();
+
+  joint_temperatures_pub_->unlockAndPublish();
 }
 
 void HardwareInterface::publishProtectiveStopRatios(const ros::Time& timestamp)
@@ -820,19 +828,53 @@ void HardwareInterface::publishJointStateExtended(const ros::Time& timestamp)
     first_time = false;
   }
 
-  // Each assign() clears old contents and copies exactly
-  msg.target_positions.assign(target_joint_positions_.begin(), target_joint_positions_.end());
+  if (has_target_joint_positions_)
+    msg.target_positions.assign(target_joint_positions_.begin(), target_joint_positions_.end());
+  else
+    msg.target_positions.clear();
   msg.actual_positions.assign(joint_positions_.begin(), joint_positions_.end());
-  msg.target_velocities.assign(target_joint_velocities_.begin(), target_joint_velocities_.end());
+
+  if (has_target_joint_velocities_)
+    msg.target_velocities.assign(target_joint_velocities_.begin(), target_joint_velocities_.end());
+  else
+    msg.target_velocities.clear();
   msg.actual_velocities.assign(joint_velocities_.begin(), joint_velocities_.end());
-  msg.target_accelerations.assign(target_joint_accelerations_.begin(),target_joint_accelerations_.end());
-  msg.target_currents.assign(target_joint_efforts_.begin(), target_joint_efforts_.end());
+
+  if (has_target_joint_accelerations_)
+    msg.target_accelerations.assign(target_joint_accelerations_.begin(), target_joint_accelerations_.end());
+  else
+    msg.target_accelerations.clear();
+
+  if (has_target_joint_efforts_)
+    msg.target_currents.assign(target_joint_efforts_.begin(), target_joint_efforts_.end());
+  else
+    msg.target_currents.clear();
   msg.actual_currents.assign(joint_efforts_.begin(), joint_efforts_.end());
-  msg.actual_current_windows.assign(joint_current_windows_.begin(), joint_current_windows_.end());
-  msg.actual_voltages.assign(joint_voltages_.begin(), joint_voltages_.end());
-  msg.target_torques.assign(target_joint_moments_.begin(), target_joint_moments_.end());
-  msg.control_modes.assign(joint_control_modes_.begin(), joint_control_modes_.end());
-  msg.joint_control_outputs.assign(joint_control_outputs_.begin(), joint_control_outputs_.end());
+
+  if (has_joint_current_windows_)
+    msg.actual_current_windows.assign(joint_current_windows_.begin(), joint_current_windows_.end());
+  else
+    msg.actual_current_windows.clear();
+
+  if (has_joint_voltages_)
+    msg.actual_voltages.assign(joint_voltages_.begin(), joint_voltages_.end());
+  else
+    msg.actual_voltages.clear();
+
+  if (has_target_joint_moments_)
+    msg.target_torques.assign(target_joint_moments_.begin(), target_joint_moments_.end());
+  else
+    msg.target_torques.clear();
+
+  if (has_joint_control_modes_)
+    msg.control_modes.assign(joint_control_modes_.begin(), joint_control_modes_.end());
+  else
+    msg.control_modes.clear();
+
+  if (has_joint_control_outputs_)
+    msg.joint_control_outputs.assign(joint_control_outputs_.begin(), joint_control_outputs_.end());
+  else
+    msg.joint_control_outputs.clear();
 
   joint_state_extended_pub_->unlockAndPublish();
 }

--- a/ur_robot_driver/src/ros/hardware_interface.cpp
+++ b/ur_robot_driver/src/ros/hardware_interface.cpp
@@ -812,11 +812,11 @@ void HardwareInterface::publishJointStateExtended(const ros::Time& timestamp)
   {
     const size_t N = joint_names_.size();
     msg.names = joint_names_;
-    msg.target_positions.reserve(N);
-    msg.actual_positions.reserve(N);
-    msg.target_velocities.reserve(N);
-    msg.actual_velocities.reserve(N);
-    msg.target_accelerations.reserve(N);
+    // msg.target_positions.reserve(N);
+    // msg.actual_positions.reserve(N);
+    // msg.target_velocities.reserve(N);
+    // msg.actual_velocities.reserve(N);
+    // msg.target_accelerations.reserve(N);
     msg.target_currents.reserve(N);
     msg.actual_currents.reserve(N);
     msg.actual_current_windows.reserve(N);
@@ -828,22 +828,22 @@ void HardwareInterface::publishJointStateExtended(const ros::Time& timestamp)
     first_time = false;
   }
 
-  if (has_target_joint_positions_)
-    msg.target_positions.assign(target_joint_positions_.begin(), target_joint_positions_.end());
-  else
-    msg.target_positions.clear();
-  msg.actual_positions.assign(joint_positions_.begin(), joint_positions_.end());
+  // if (has_target_joint_positions_)
+  //   msg.target_positions.assign(target_joint_positions_.begin(), target_joint_positions_.end());
+  // else
+  //   msg.target_positions.clear();
+  // msg.actual_positions.assign(joint_positions_.begin(), joint_positions_.end());
 
-  if (has_target_joint_velocities_)
-    msg.target_velocities.assign(target_joint_velocities_.begin(), target_joint_velocities_.end());
-  else
-    msg.target_velocities.clear();
-  msg.actual_velocities.assign(joint_velocities_.begin(), joint_velocities_.end());
+  // if (has_target_joint_velocities_)
+  //   msg.target_velocities.assign(target_joint_velocities_.begin(), target_joint_velocities_.end());
+  // else
+  //   msg.target_velocities.clear();
+  // msg.actual_velocities.assign(joint_velocities_.begin(), joint_velocities_.end());
 
-  if (has_target_joint_accelerations_)
-    msg.target_accelerations.assign(target_joint_accelerations_.begin(), target_joint_accelerations_.end());
-  else
-    msg.target_accelerations.clear();
+  // if (has_target_joint_accelerations_)
+  //   msg.target_accelerations.assign(target_joint_accelerations_.begin(), target_joint_accelerations_.end());
+  // else
+  //   msg.target_accelerations.clear();
 
   if (has_target_joint_efforts_)
     msg.target_currents.assign(target_joint_efforts_.begin(), target_joint_efforts_.end());

--- a/ur_robot_driver/src/ros/hardware_interface.cpp
+++ b/ur_robot_driver/src/ros/hardware_interface.cpp
@@ -512,6 +512,7 @@ void HardwareInterface::read(const ros::Time& time, const ros::Duration& period)
              ur_extra_msgs::ProtectiveStopRatios::UNKNOWN_RATIO);
     readData(data_pkg, "collision_detection_ratio", collision_detection_ratio_, false,
              ur_extra_msgs::ProtectiveStopRatios::UNKNOWN_RATIO);
+    readData(data_pkg, "time_scale_source", time_scale_source_, false, 0);
 
     extractRobotStatus();
 
@@ -794,6 +795,7 @@ void HardwareInterface::publishProtectiveStopRatios(const ros::Time& timestamp)
       pstop_ratios_pub_->msg_.header.stamp = timestamp;
       pstop_ratios_pub_->msg_.collision_detection_ratio = collision_detection_ratio_;
       pstop_ratios_pub_->msg_.joint_position_deviation_ratio = joint_position_deviation_ratio_;
+      pstop_ratios_pub_->msg_.time_scale_source = time_scale_source_;
       pstop_ratios_pub_->unlockAndPublish();
     }
   }

--- a/ur_robot_driver/src/ros/hardware_interface.cpp
+++ b/ur_robot_driver/src/ros/hardware_interface.cpp
@@ -405,6 +405,23 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
         resp.success = this->ur_driver_->sendScript(cmd.str());
         return true;
       });
+    
+  // joint temperature publisher: reserve capacity for temperatures.
+  const size_t N = joint_names_.size();
+  auto& temperatures_msg = joint_temperatures_pub_->msg_;
+  temperatures_msg.joint_names = joint_names_;
+  temperatures_msg.temperatures.reserve(N);
+
+  // joint state extended publisher: copy joint names and reserve capacity.
+  auto& joint_state_extended_msg = joint_state_extended_pub_->msg_;
+  joint_state_extended_msg.names = joint_names_;
+  joint_state_extended_msg.target_currents.reserve(N);
+  joint_state_extended_msg.actual_currents.reserve(N);
+  joint_state_extended_msg.actual_current_windows.reserve(N);
+  joint_state_extended_msg.actual_voltages.reserve(N);
+  joint_state_extended_msg.target_torques.reserve(N);
+  joint_state_extended_msg.joint_control_modes.reserve(N);
+  joint_state_extended_msg.joint_control_outputs.reserve(N);
 
   return true;
 }
@@ -758,22 +775,11 @@ void HardwareInterface::publishJointTemperatures(const ros::Time& timestamp)
   auto& msg = joint_temperatures_pub_->msg_;
   msg.header.stamp = timestamp;
 
-  // One-time setup: reserve capacity for names & temps
-  static bool first_time = true;
-  if (first_time)
-  {
-    const size_t N = joint_names_.size();
-    msg.joint_names = joint_names_;
-    msg.joint_names.reserve(N);
-    msg.temperatures.reserve(N);
-
-    first_time = false;
-  }
-
-  if (has_joint_temperatures_)
+  if (has_joint_temperatures_) {
     msg.temperatures.assign(joint_temperatures_.begin(), joint_temperatures_.end());
-  else
+  } else {
     msg.temperatures.clear();
+  }
 
   joint_temperatures_pub_->unlockAndPublish();
 }
@@ -795,61 +801,53 @@ void HardwareInterface::publishProtectiveStopRatios(const ros::Time& timestamp)
 
 void HardwareInterface::publishJointStateExtended(const ros::Time& timestamp)
 {
-  if (!joint_state_extended_pub_)
+  if (!joint_state_extended_pub_) {
     return;
-  if (!joint_state_extended_pub_->trylock())
+  }
+  if (!joint_state_extended_pub_->trylock()) {
     return;
+  }
 
   auto& msg = joint_state_extended_pub_->msg_;
   msg.header.stamp = timestamp;
 
-  // One-time initialization: copy joint names and reserve capacity
-  static bool first_time = true;
-  if (first_time)
-  {
-    const size_t N = joint_names_.size();
-    msg.names = joint_names_;
-    msg.target_currents.reserve(N);
-    msg.actual_currents.reserve(N);
-    msg.actual_current_windows.reserve(N);
-    msg.actual_voltages.reserve(N);
-    msg.target_torques.reserve(N);
-    msg.control_modes.reserve(N);
-    msg.joint_control_outputs.reserve(N);
-
-    first_time = false;
+  if (has_target_joint_efforts_) {
+    msg.target_currents.assign(target_joint_efforts_.begin(), target_joint_efforts_.end());
+  } else {
+    msg.target_currents.clear();
   }
 
-  if (has_target_joint_efforts_)
-    msg.target_currents.assign(target_joint_efforts_.begin(), target_joint_efforts_.end());
-  else
-    msg.target_currents.clear();
   msg.actual_currents.assign(joint_efforts_.begin(), joint_efforts_.end());
 
-  if (has_joint_current_windows_)
+  if (has_joint_current_windows_) {
     msg.actual_current_windows.assign(joint_current_windows_.begin(), joint_current_windows_.end());
-  else
+  } else {
     msg.actual_current_windows.clear();
+  }
 
-  if (has_joint_voltages_)
+  if (has_joint_voltages_) {
     msg.actual_voltages.assign(joint_voltages_.begin(), joint_voltages_.end());
-  else
+  } else {
     msg.actual_voltages.clear();
+  }
 
-  if (has_target_joint_moments_)
+  if (has_target_joint_moments_) {
     msg.target_torques.assign(target_joint_moments_.begin(), target_joint_moments_.end());
-  else
+  } else {
     msg.target_torques.clear();
+  }
 
-  if (has_joint_control_modes_)
-    msg.control_modes.assign(joint_control_modes_.begin(), joint_control_modes_.end());
-  else
-    msg.control_modes.clear();
+  if (has_joint_control_modes_) {
+    msg.joint_control_modes.assign(joint_control_modes_.begin(), joint_control_modes_.end());
+  } else {
+    msg.joint_control_modes.clear();
+  }
 
-  if (has_joint_control_outputs_)
+  if (has_joint_control_outputs_) {
     msg.joint_control_outputs.assign(joint_control_outputs_.begin(), joint_control_outputs_.end());
-  else
+  } else {
     msg.joint_control_outputs.clear();
+  }
 
   joint_state_extended_pub_->unlockAndPublish();
 }

--- a/ur_robot_driver/src/ros/hardware_interface.cpp
+++ b/ur_robot_driver/src/ros/hardware_interface.cpp
@@ -470,20 +470,20 @@ void HardwareInterface::read(const ros::Time& time, const ros::Duration& period)
   if (data_pkg)
   {
     packet_read_ = true;
-    readData(data_pkg, "target_q", target_joint_positions_);
-    readData(data_pkg, "target_qd", target_joint_velocities_);
-    readData(data_pkg, "target_qdd", target_joint_accelerations_);
-    readData(data_pkg, "target_current", target_joint_efforts_);
-    readData(data_pkg, "target_moment", target_joint_moments_);
+    readData(data_pkg, "target_q", target_joint_positions_, false);
+    readData(data_pkg, "target_qd", target_joint_velocities_, false);
+    readData(data_pkg, "target_qdd", target_joint_accelerations_, false);
+    readData(data_pkg, "target_current", target_joint_efforts_, false);
+    readData(data_pkg, "target_moment", target_joint_moments_, false);
     readData(data_pkg, "actual_q", joint_positions_);
     readData(data_pkg, "actual_qd", joint_velocities_);
-    readData(data_pkg, "actual_qdd", joint_accelerations_);
+    readData(data_pkg, "actual_qdd", joint_accelerations_, false);
     readData(data_pkg, "actual_current", joint_efforts_);
-    readData(data_pkg, "actual_current_window", joint_current_windows_);
-    readData(data_pkg, "actual_moment", joint_moments_);
-    readData(data_pkg, "joint_control_output", joint_control_outputs_);
+    readData(data_pkg, "actual_current_window", joint_current_windows_, false);
+    readData(data_pkg, "actual_moment", joint_moments_, false);
+    readData(data_pkg, "joint_control_output", joint_control_outputs_, false);
     readData(data_pkg, "joint_temperatures", joint_temperatures_);
-    readData(data_pkg, "actual_joint_voltage", joint_voltages_);
+    readData(data_pkg, "actual_joint_voltage", joint_voltages_, false);
     readData(data_pkg, "target_speed_fraction", target_speed_fraction_);
     readData(data_pkg, "speed_scaling", speed_scaling_);
     readData(data_pkg, "runtime_state", runtime_state_);
@@ -500,7 +500,7 @@ void HardwareInterface::read(const ros::Time& time, const ros::Duration& period)
     readData(data_pkg, "tool_output_current", tool_output_current_);
     readData(data_pkg, "tool_temperature", tool_temperature_);
     readData(data_pkg, "robot_mode", robot_mode_);
-    readData(data_pkg, "joint_mode", joint_modes_);
+    readData(data_pkg, "joint_mode", joint_modes_, false);
     readData(data_pkg, "safety_mode", safety_mode_);
     readBitsetData<uint32_t>(data_pkg, "robot_status_bits", robot_status_bits_);
     readBitsetData<uint32_t>(data_pkg, "safety_status_bits", safety_status_bits_);

--- a/ur_robot_driver/src/ros/hardware_interface.cpp
+++ b/ur_robot_driver/src/ros/hardware_interface.cpp
@@ -50,21 +50,10 @@ static const std::bitset<11> in_error_bitset_(1 << toUnderlying(UrRtdeSafetyStat
 HardwareInterface::HardwareInterface()
   : joint_position_command_({ 0, 0, 0, 0, 0, 0 })
   , joint_velocity_command_({ 0, 0, 0, 0, 0, 0 })
-  , target_joint_positions_{ { 0, 0, 0, 0, 0, 0 } }
   , joint_positions_{ { 0, 0, 0, 0, 0, 0 } }
-  , target_joint_velocities_{ { 0, 0, 0, 0, 0, 0 } }
   , joint_velocities_{ { 0, 0, 0, 0, 0, 0 } }
-  , target_joint_accelerations_{ { 0, 0, 0, 0, 0, 0 } }
-  , joint_accelerations_{ { 0, 0, 0, 0, 0, 0 } }
-  , target_joint_efforts_{ { 0, 0, 0, 0, 0, 0 } }
   , joint_efforts_{ { 0, 0, 0, 0, 0, 0 } }
-  , joint_current_windows_{ { 0, 0, 0, 0, 0, 0 } }
-  , target_joint_moments_{ { 0, 0, 0, 0, 0, 0 } }
-  , joint_moments_{ { 0, 0, 0, 0, 0, 0 } }
-  , joint_control_outputs_{ { 0, 0, 0, 0, 0, 0 } }
-  , joint_voltages_{ { 0, 0, 0, 0, 0, 0 } }
   , joint_temperatures_{ { 0, 0, 0, 0, 0, 0 } }
-  , joint_modes_{ { 0, 0, 0, 0, 0, 0 } }
   , standard_analog_input_{ { 0, 0 } }
   , standard_analog_output_{ { 0, 0 } }
   , joint_names_(6)
@@ -470,20 +459,17 @@ void HardwareInterface::read(const ros::Time& time, const ros::Duration& period)
   if (data_pkg)
   {
     packet_read_ = true;
-    readData(data_pkg, "target_q", target_joint_positions_, false);
-    readData(data_pkg, "target_qd", target_joint_velocities_, false);
-    readData(data_pkg, "target_qdd", target_joint_accelerations_, false);
-    readData(data_pkg, "target_current", target_joint_efforts_, false);
-    readData(data_pkg, "target_moment", target_joint_moments_, false);
+    readData(data_pkg, "target_q", target_joint_positions_, false, decltype(target_joint_positions_){});
+    readData(data_pkg, "target_qd", target_joint_velocities_, false, decltype(target_joint_velocities_){});
+    readData(data_pkg, "target_qdd", target_joint_accelerations_, false, decltype(target_joint_accelerations_){});
+    readData(data_pkg, "target_current", target_joint_efforts_, false, decltype(target_joint_efforts_){});
+    readData(data_pkg, "target_moment", target_joint_moments_, false, decltype(target_joint_moments_){});
     readData(data_pkg, "actual_q", joint_positions_);
     readData(data_pkg, "actual_qd", joint_velocities_);
-    readData(data_pkg, "actual_qdd", joint_accelerations_, false);
     readData(data_pkg, "actual_current", joint_efforts_);
-    readData(data_pkg, "actual_current_window", joint_current_windows_, false);
-    readData(data_pkg, "actual_moment", joint_moments_, false);
-    readData(data_pkg, "joint_control_output", joint_control_outputs_, false);
+    readData(data_pkg, "actual_current_window", joint_current_windows_, false, decltype(joint_current_windows_){});
     readData(data_pkg, "joint_temperatures", joint_temperatures_);
-    readData(data_pkg, "actual_joint_voltage", joint_voltages_, false);
+    readData(data_pkg, "actual_joint_voltage", joint_voltages_, false, decltype(joint_voltages_){});
     readData(data_pkg, "target_speed_fraction", target_speed_fraction_);
     readData(data_pkg, "speed_scaling", speed_scaling_);
     readData(data_pkg, "runtime_state", runtime_state_);
@@ -500,7 +486,8 @@ void HardwareInterface::read(const ros::Time& time, const ros::Duration& period)
     readData(data_pkg, "tool_output_current", tool_output_current_);
     readData(data_pkg, "tool_temperature", tool_temperature_);
     readData(data_pkg, "robot_mode", robot_mode_);
-    readData(data_pkg, "joint_mode", joint_modes_, false);
+    readData(data_pkg, "joint_mode", joint_control_modes_, false, decltype(joint_control_modes_){});
+    readData(data_pkg, "joint_control_output", joint_control_outputs_, false, decltype(joint_control_outputs_){});
     readData(data_pkg, "safety_mode", safety_mode_);
     readBitsetData<uint32_t>(data_pkg, "robot_status_bits", robot_status_bits_);
     readBitsetData<uint32_t>(data_pkg, "safety_status_bits", safety_status_bits_);
@@ -805,69 +792,47 @@ void HardwareInterface::publishJointStateExtended(const ros::Time& timestamp)
 {
   if (!joint_state_extended_pub_)
     return;
-
   if (!joint_state_extended_pub_->trylock())
     return;
 
   auto& msg = joint_state_extended_pub_->msg_;
   msg.header.stamp = timestamp;
 
-  // One-time initialization: copy joint names and pre-size all arrays
+  // One-time initialization: copy joint names and reserve capacity
   static bool first_time = true;
   if (first_time)
   {
     const size_t N = joint_names_.size();
     msg.names = joint_names_;
-
-    msg.target_positions.resize(N);
-    msg.actual_positions.resize(N);
-
-    msg.target_velocities.resize(N);
-    msg.actual_velocities.resize(N);
-
-    msg.target_accelerations.resize(N);
-    msg.actual_accelerations.resize(N);
-
-    msg.target_currents.resize(N);
-    msg.actual_currents.resize(N);
-    msg.actual_current_windows.resize(N);
-    msg.joint_control_outputs.resize(N);
-
-    msg.actual_voltages.resize(N);
-
-    msg.target_torques.resize(N);
-    msg.actual_torques.resize(N);
-
-    msg.temperatures.resize(N);
-    msg.control_modes.resize(N);
+    msg.target_positions.reserve(N);
+    msg.actual_positions.reserve(N);
+    msg.target_velocities.reserve(N);
+    msg.actual_velocities.reserve(N);
+    msg.target_accelerations.reserve(N);
+    msg.target_currents.reserve(N);
+    msg.actual_currents.reserve(N);
+    msg.actual_current_windows.reserve(N);
+    msg.actual_voltages.reserve(N);
+    msg.target_torques.reserve(N);
+    msg.control_modes.reserve(N);
+    msg.joint_control_outputs.reserve(N);
 
     first_time = false;
   }
 
-  // Fast, deterministic in-place updates every cycle
-  std::copy(target_joint_positions_.begin(),    target_joint_positions_.end(),    msg.target_positions.begin());
-  std::copy(joint_positions_.begin(),           joint_positions_.end(),           msg.actual_positions.begin());
-
-  std::copy(target_joint_velocities_.begin(),   target_joint_velocities_.end(),   msg.target_velocities.begin());
-  std::copy(joint_velocities_.begin(),          joint_velocities_.end(),          msg.actual_velocities.begin());
-
-  std::copy(target_joint_accelerations_.begin(),target_joint_accelerations_.end(),msg.target_accelerations.begin());
-  std::copy(joint_accelerations_.begin(),       joint_accelerations_.end(),       msg.actual_accelerations.begin());
-
-  std::copy(target_joint_efforts_.begin(),      target_joint_efforts_.end(),      msg.target_currents.begin());
-  std::copy(joint_efforts_.begin(),             joint_efforts_.end(),             msg.actual_currents.begin());
-  std::copy(joint_current_windows_.begin(),     joint_current_windows_.end(),     msg.actual_current_windows.begin());
-  std::copy(joint_control_outputs_.begin(),     joint_control_outputs_.end(),     msg.joint_control_outputs.begin());
-
-  std::copy(joint_voltages_.begin(),            joint_voltages_.end(),            msg.actual_voltages.begin());
-
-  std::copy(target_joint_moments_.begin(),      target_joint_moments_.end(),      msg.target_torques.begin());
-  std::copy(joint_moments_.begin(),             joint_moments_.end(),             msg.actual_torques.begin());
-
-  std::copy(joint_temperatures_.begin(),        joint_temperatures_.end(),        msg.temperatures.begin());
-
-  // joint_modes_ is an integer array
-  std::copy(joint_modes_.begin(),               joint_modes_.end(),               msg.control_modes.begin());
+  // Each assign() clears old contents and copies exactly
+  msg.target_positions.assign(target_joint_positions_.begin(), target_joint_positions_.end());
+  msg.actual_positions.assign(joint_positions_.begin(), joint_positions_.end());
+  msg.target_velocities.assign(target_joint_velocities_.begin(), target_joint_velocities_.end());
+  msg.actual_velocities.assign(joint_velocities_.begin(), joint_velocities_.end());
+  msg.target_accelerations.assign(target_joint_accelerations_.begin(),target_joint_accelerations_.end());
+  msg.target_currents.assign(target_joint_efforts_.begin(), target_joint_efforts_.end());
+  msg.actual_currents.assign(joint_efforts_.begin(), joint_efforts_.end());
+  msg.actual_current_windows.assign(joint_current_windows_.begin(), joint_current_windows_.end());
+  msg.actual_voltages.assign(joint_voltages_.begin(), joint_voltages_.end());
+  msg.target_torques.assign(target_joint_moments_.begin(), target_joint_moments_.end());
+  msg.control_modes.assign(joint_control_modes_.begin(), joint_control_modes_.end());
+  msg.joint_control_outputs.assign(joint_control_outputs_.begin(), joint_control_outputs_.end());
 
   joint_state_extended_pub_->unlockAndPublish();
 }

--- a/ur_robot_driver/src/ros/hardware_interface.cpp
+++ b/ur_robot_driver/src/ros/hardware_interface.cpp
@@ -458,9 +458,6 @@ void HardwareInterface::read(const ros::Time& time, const ros::Duration& period)
   if (data_pkg)
   {
     packet_read_ = true;
-    has_target_joint_positions_ = readData(data_pkg, "target_q", target_joint_positions_, false);
-    has_target_joint_velocities_ = readData(data_pkg, "target_qd", target_joint_velocities_, false);
-    has_target_joint_accelerations_ = readData(data_pkg, "target_qdd", target_joint_accelerations_, false);
     has_target_joint_efforts_ = readData(data_pkg, "target_current", target_joint_efforts_, false);
     has_target_joint_moments_ = readData(data_pkg, "target_moment", target_joint_moments_, false);
     readData(data_pkg, "actual_q", joint_positions_);
@@ -812,11 +809,6 @@ void HardwareInterface::publishJointStateExtended(const ros::Time& timestamp)
   {
     const size_t N = joint_names_.size();
     msg.names = joint_names_;
-    // msg.target_positions.reserve(N);
-    // msg.actual_positions.reserve(N);
-    // msg.target_velocities.reserve(N);
-    // msg.actual_velocities.reserve(N);
-    // msg.target_accelerations.reserve(N);
     msg.target_currents.reserve(N);
     msg.actual_currents.reserve(N);
     msg.actual_current_windows.reserve(N);
@@ -827,23 +819,6 @@ void HardwareInterface::publishJointStateExtended(const ros::Time& timestamp)
 
     first_time = false;
   }
-
-  // if (has_target_joint_positions_)
-  //   msg.target_positions.assign(target_joint_positions_.begin(), target_joint_positions_.end());
-  // else
-  //   msg.target_positions.clear();
-  // msg.actual_positions.assign(joint_positions_.begin(), joint_positions_.end());
-
-  // if (has_target_joint_velocities_)
-  //   msg.target_velocities.assign(target_joint_velocities_.begin(), target_joint_velocities_.end());
-  // else
-  //   msg.target_velocities.clear();
-  // msg.actual_velocities.assign(joint_velocities_.begin(), joint_velocities_.end());
-
-  // if (has_target_joint_accelerations_)
-  //   msg.target_accelerations.assign(target_joint_accelerations_.begin(), target_joint_accelerations_.end());
-  // else
-  //   msg.target_accelerations.clear();
 
   if (has_target_joint_efforts_)
     msg.target_currents.assign(target_joint_efforts_.begin(), target_joint_efforts_.end());

--- a/ur_robot_driver/src/ros/hardware_interface.cpp
+++ b/ur_robot_driver/src/ros/hardware_interface.cpp
@@ -415,7 +415,7 @@ bool HardwareInterface::readData(const std::unique_ptr<rtde_interface::DataPacka
 {
   if (data_pkg->getData(var_name, data))
   {
-    return true; // actual data arrived
+    return true;
   }
   if (throw_on_error)
   {
@@ -424,7 +424,7 @@ bool HardwareInterface::readData(const std::unique_ptr<rtde_interface::DataPacka
     throw std::runtime_error(error_msg);
   }
   data = default_value;
-  return false; // we used the default
+  return false;
 }
 
 template <typename T, size_t N>
@@ -878,8 +878,6 @@ void HardwareInterface::publishJointStateExtended(const ros::Time& timestamp)
 
   joint_state_extended_pub_->unlockAndPublish();
 }
-
-
 
 void HardwareInterface::extractRobotStatus()
 {

--- a/ur_robot_driver/src/rtde/data_package.cpp
+++ b/ur_robot_driver/src/rtde/data_package.cpp
@@ -39,10 +39,12 @@ std::unordered_map<std::string, DataPackage::_rtde_type_variant> DataPackage::g_
   { "target_moment", vector6d_t() },
   { "actual_q", vector6d_t() },
   { "actual_qd", vector6d_t() },
+  // NB: Not available over RTDE
   { "actual_qdd", vector6d_t() },
-  { "actual_current", vector6d_t() },
+  //{ "actual_current", vector6d_t() },
   { "actual_current_window", vector6d_t() },
-  { "actual_moment", vector6d_t() },
+  // NB: Not available over RTDE
+  //{ "actual_moment", vector6d_t() },
   { "joint_control_output", vector6d_t() },
   { "actual_TCP_pose", vector6d_t() },
   { "actual_TCP_speed", vector6d_t() },

--- a/ur_robot_driver/src/rtde/data_package.cpp
+++ b/ur_robot_driver/src/rtde/data_package.cpp
@@ -40,8 +40,8 @@ std::unordered_map<std::string, DataPackage::_rtde_type_variant> DataPackage::g_
   { "actual_q", vector6d_t() },
   { "actual_qd", vector6d_t() },
   // NB: Not available over RTDE
-  { "actual_qdd", vector6d_t() },
-  //{ "actual_current", vector6d_t() },
+  //{ "actual_qdd", vector6d_t() },
+  { "actual_current", vector6d_t() },
   { "actual_current_window", vector6d_t() },
   // NB: Not available over RTDE
   //{ "actual_moment", vector6d_t() },

--- a/ur_robot_driver/src/rtde/data_package.cpp
+++ b/ur_robot_driver/src/rtde/data_package.cpp
@@ -41,6 +41,7 @@ std::unordered_map<std::string, DataPackage::_rtde_type_variant> DataPackage::g_
   { "actual_qd", vector6d_t() },
   { "actual_qdd", vector6d_t() },
   { "actual_current", vector6d_t() },
+  { "actual_current_window", vector6d_t() },
   { "actual_moment", vector6d_t() },
   { "joint_control_output", vector6d_t() },
   { "actual_TCP_pose", vector6d_t() },

--- a/ur_robot_driver/src/rtde/data_package.cpp
+++ b/ur_robot_driver/src/rtde/data_package.cpp
@@ -71,6 +71,7 @@ std::unordered_map<std::string, DataPackage::_rtde_type_variant> DataPackage::g_
   { "safety_status_bits", uint32_t() },
   { "joint_position_deviation_ratio", double() },
   { "collision_detection_ratio", double() },
+  { "time_scale_source", int32_t() },
   { "analog_io_types", uint32_t() },
   { "standard_analog_input0", double() },
   { "standard_analog_input1", double() },


### PR DESCRIPTION
Towards SW-1427

This PR adds a message to `ur_extra_msgs`, `JointStateExtended.msg`, and populates+publishes it from the hardware-interface. As currently implemented, this message will be published every RTDE read tick (usually 500 Hz); if we're concerned about this, then I can add a launch arg for enabling/disabling this. At the moment nothing upstream relies on this data, but we do want it for tuning and investigating pstops/faults; it is generally useful information. It loses some usefulness if we downsample it, since we usually want to see values at exact instances, but downsampling is an option as well.

This PR also adds `time_scale_source` to `ProtectiveStopRatios.msg`; this is useful to know why time scaling is occurring -- more in [the RTDE guide](https://www.universal-robots.com/articles/ur/interface-communication/real-time-data-exchange-rtde-guide/).

### Testing
- [x] on module spoof pick and place
each rolling bag increases by ~3MB in size.