### PR TITLE
Use `mass` instead of `payload` when using `ur_msgs.SetPayload`

### DIFF
--- a/ur_robot_driver/src/ros/hardware_interface.cpp
+++ b/ur_robot_driver/src/ros/hardware_interface.cpp
@@ -397,7 +397,7 @@ bool HardwareInterface::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw
         std::stringstream cmd;
         cmd.imbue(std::locale::classic());  // Make sure, decimal divider is actually '.'
         cmd << "sec setup():" << std::endl
-            << " set_payload(" << req.payload << ", [" << req.center_of_gravity.x << ", " << req.center_of_gravity.y
+            << " set_payload(" << req.mass << ", [" << req.center_of_gravity.x << ", " << req.center_of_gravity.y
             << ", " << req.center_of_gravity.z << "])" << std::endl
             << "end";
         resp.success = this->ur_driver_->sendScript(cmd.str());


### PR DESCRIPTION
We're going to use the [ros-industrial:ur_msgs](https://github.com/ros-industrial/ur_msgs) package going forward; but, the latest melodic package updated the `SetPayload.request` to use `mass` instead of `payload`, so we need to update the usage in the driver. This happened because our version of the driver has lagged behind -- further upstream this change is already taken care of.